### PR TITLE
Fix: Add input validation for paddle speed (closes #42)

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,14 +3,25 @@ import pygame
 import sys
 
 # --- Vulnerable Input: Paddle speed from command-line ---
-try:
+def get_valid_paddle_speed():
+    # Check if argument is provided
+    if len(sys.argv) < 2:
+        print("No paddle speed argument provided. Using default value 5.")
+        return 5
     user_input = sys.argv[1]
+    # Validate input: must be integer, within reasonable range
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if 1 <= paddle_speed <= 20:
+            return paddle_speed
+        else:
+            print("Paddle speed out of allowed range (1-20). Using default value 5.")
+            return 5
     else:
-        raise ValueError("Invalid input: Only positive integers are allowed.")
-except (IndexError, ValueError):
-    paddle_speed = 5  # Fallback default
+        print("Invalid input: Only positive integers are allowed. Using default value 5.")
+        return 5
+
+paddle_speed = get_valid_paddle_speed()
 
 # --- Pygame Setup ---
 pygame.init()


### PR DESCRIPTION
This pull request addresses the security vulnerability described in issue #42 by adding checks for the presence of a command-line argument and validating the integer range for paddle speed. The fix ensures the script does not crash when no argument is provided and prevents resource exhaustion by restricting the allowed range. See the issue for details and supporting references.