### PR TITLE
Fix: Enforce input validation for paddle speed (range 1-20) in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # --- Security Fix: Enforce paddle speed range ---
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the security vulnerability described in [Issue #61](https://github.com/aifuturesdemos/mycustomapp/issues/61) by enforcing strict input validation for paddle speed in main.py. User input is now restricted to integers between 1 and 20, preventing resource exhaustion and unintended behavior. Please review and merge to improve the application's security.