### PR TITLE
Fix: Stricter input validation for paddle speed in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,14 +3,17 @@ import pygame
 import sys
 
 # --- Vulnerable Input: Paddle speed from command-line ---
-try:
-    user_input = sys.argv[1]
-    if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
-    else:
-        raise ValueError("Invalid input: Only positive integers are allowed.")
-except (IndexError, ValueError):
-    paddle_speed = 5  # Fallback default
+def get_validated_input():
+    try:
+        user_input = sys.argv[1]
+        # Improved: Only allow positive integers, no leading zeros
+        if re.fullmatch(r'[1-9]\d*', user_input):
+            paddle_speed = int(user_input)
+        else:
+            raise ValueError("Invalid input: Only positive integers are allowed.")
+    except (IndexError, ValueError):
+        paddle_speed = 5  # Fallback default
+    return paddle_speed
 
 # --- Pygame Setup ---
 pygame.init()
@@ -26,6 +29,7 @@ paddle = pygame.Rect(width - 20, height // 2 - 60, 10, 120)
 # Main Game Loop
 running = True
 clock = pygame.time.Clock()
+paddle_speed = get_validated_input()
 
 while running:
     for event in pygame.event.get():


### PR DESCRIPTION
This pull request addresses a security vulnerability in main.py by implementing stricter input validation for paddle speed. Only positive integers are now allowed, with a fallback to a default value if invalid input is provided. This resolves the issue documented in #387.