### PR TITLE
Security Fix: Restrict Paddle Speed Input to Safe Range

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,18 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
+MIN_PADDLE_SPEED = 1
+MAX_PADDLE_SPEED = 20
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if MIN_PADDLE_SPEED <= paddle_speed <= MAX_PADDLE_SPEED:
+            pass  # Valid input
+        else:
+            print(f"Paddle speed must be between {MIN_PADDLE_SPEED} and {MAX_PADDLE_SPEED}. Using default value.")
+            paddle_speed = 5
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):
@@ -16,7 +23,7 @@ except (IndexError, ValueError):
 pygame.init()
 width, height = 800, 600
 screen = pygame.display.set_mode((width, height))
-pygame.display.set_caption("Vulnerable Ping Pong")
+pygame.display.set_caption("Secure Ping Pong")
 
 # Game Elements
 ball = pygame.Rect(width // 2, height // 2, 15, 15)


### PR DESCRIPTION
This pull request addresses a security vulnerability in main.py where paddle speed input from the command line was not properly restricted. The fix enforces a safe range (1-20) for paddle speed and provides user feedback for invalid values. See [issue #552](https://github.com/aifuturesdemos/mycustomapp/issues/552) for details and references.