### PR TITLE
Security Fix: Enforce Upper Bound on Paddle Speed in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,10 +3,13 @@ import pygame
 import sys
 
 # --- Vulnerable Input: Paddle speed from command-line ---
+MAX_PADDLE_SPEED = 20  # Upper bound for paddle speed
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > MAX_PADDLE_SPEED:
+            paddle_speed = MAX_PADDLE_SPEED  # Enforce upper bound
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the security vulnerability identified in issue # by enforcing an upper bound (MAX_PADDLE_SPEED = 20) on paddle speed input in main.py. This mitigates the risk of denial of service or game instability due to excessively large input values. Please review and merge to improve application security and stability.