### PR TITLE
Fix: Restrict Paddle Speed Input Range for Security (Issue #574)

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,13 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):
@@ -16,7 +18,7 @@ except (IndexError, ValueError):
 pygame.init()
 width, height = 800, 600
 screen = pygame.display.set_mode((width, height))
-pygame.display.set_caption("Vulnerable Ping Pong")
+pygame.display.set_caption("Secure Ping Pong")
 
 # Game Elements
 ball = pygame.Rect(width // 2, height // 2, 15, 15)


### PR DESCRIPTION
This pull request addresses the security vulnerability documented in issue #574 by enforcing a strict range (1-20) for paddle_speed input in main.py. This prevents denial of service and gameplay disruption due to excessively large values. Input validation is improved and robust error handling is implemented. Please review the changes and merge into main.