### PR TITLE
Security Fix: Enforce Bounds on Paddle Speed Input in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,15 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line with bounds enforcement ---
+MIN_PADDLE_SPEED = 1
+MAX_PADDLE_SPEED = 20
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (MIN_PADDLE_SPEED <= paddle_speed <= MAX_PADDLE_SPEED):
+            raise ValueError(f"Paddle speed must be between {MIN_PADDLE_SPEED} and {MAX_PADDLE_SPEED}.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):
@@ -16,7 +20,7 @@ except (IndexError, ValueError):
 pygame.init()
 width, height = 800, 600
 screen = pygame.display.set_mode((width, height))
-pygame.display.set_caption("Vulnerable Ping Pong")
+pygame.display.set_caption("Secure Ping Pong")
 
 # Game Elements
 ball = pygame.Rect(width // 2, height // 2, 15, 15)
@@ -58,3 +62,5 @@ while running:
     clock.tick(60)
 
 pygame.quit()
+
+# Security improvement: Paddle speed input is now strictly validated and bounded to prevent resource exhaustion and gameplay issues.


### PR DESCRIPTION
This pull request addresses the security vulnerability documented in issue #577 by enforcing strict bounds on the paddle_speed input (allowed values: 1 to 20) and improving input validation. Comments have been added to explain the security improvements. Please review and merge.