### PR TITLE
Fix: Restrict paddle_speed to 1-20, use argparse, and add logging for invalid input

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,22 +1,29 @@
-import re
+import argparse
+import logging
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
-try:
-    user_input = sys.argv[1]
-    if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+# --- Logging Setup ---
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# --- Secure Input: Paddle speed from command-line ---
+def get_paddle_speed():
+    parser = argparse.ArgumentParser(description="Set paddle speed (1-20)")
+    parser.add_argument('paddle_speed', nargs='?', default=5, type=int, help='Paddle speed (1-20)')
+    args = parser.parse_args()
+    if 1 <= args.paddle_speed <= 20:
+        return args.paddle_speed
     else:
-        raise ValueError("Invalid input: Only positive integers are allowed.")
-except (IndexError, ValueError):
-    paddle_speed = 5  # Fallback default
+        logging.warning(f"Invalid paddle_speed: {args.paddle_speed}. Using default value 5.")
+        return 5
+
+paddle_speed = get_paddle_speed()
 
 # --- Pygame Setup ---
 pygame.init()
 width, height = 800, 600
 screen = pygame.display.set_mode((width, height))
-pygame.display.set_caption("Vulnerable Ping Pong")
+pygame.display.set_caption("Secure Ping Pong")
 
 # Game Elements
 ball = pygame.Rect(width // 2, height // 2, 15, 15)


### PR DESCRIPTION
This pull request addresses the security vulnerability described in issue #581 by:
- Using argparse for robust command-line argument parsing
- Restricting paddle_speed to a safe range (1-20)
- Adding logging for invalid input attempts

This improves the security and reliability of the application.