### PR TITLE
Mitigate Security Vulnerability: Restrict Paddle Speed Input (1-20) in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,11 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Add upper bound check for paddle_speed
+        if paddle_speed < 1:
+            paddle_speed = 1
+        elif paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the security vulnerability documented in issue #587 by adding an upper bound check for paddle_speed in main.py. Paddle speed is now restricted to the range 1-20, preventing potential denial of service or gameplay instability due to excessively high values.\n\n- Input is validated as a positive integer and clamped to [1, 20].\n- Follows best practices for input validation (see OWASP Input Validation Cheat Sheet, Python Security Best Practices).\n\nPlease review and merge to ensure stable and secure gameplay.