### PR TITLE
Security Fix: Restrict Paddle Speed Input Range in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,21 +2,26 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
+MIN_PADDLE_SPEED = 1
+MAX_PADDLE_SPEED = 20
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (MIN_PADDLE_SPEED <= paddle_speed <= MAX_PADDLE_SPEED):
+            raise ValueError(f"Paddle speed must be between {MIN_PADDLE_SPEED} and {MAX_PADDLE_SPEED}.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
-except (IndexError, ValueError):
+except (IndexError, ValueError) as e:
+    print(f"[Warning] {e} Using default paddle speed.")
     paddle_speed = 5  # Fallback default
 
 # --- Pygame Setup ---
 pygame.init()
 width, height = 800, 600
 screen = pygame.display.set_mode((width, height))
-pygame.display.set_caption("Vulnerable Ping Pong")
+pygame.display.set_caption("Secure Ping Pong")
 
 # Game Elements
 ball = pygame.Rect(width // 2, height // 2, 15, 15)


### PR DESCRIPTION
This pull request addresses the security vulnerability documented in issue #591 by restricting the paddle_speed input to a safe range (1-20) and adding error handling for out-of-range values. This ensures stable gameplay and aligns with secure coding best practices.