### PR TITLE
Fix: Restrict paddle_speed to safe range and improve input validation (issue #599)

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,21 +2,28 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
+MIN_PADDLE_SPEED = 1
+MAX_PADDLE_SPEED = 20
+DEFAULT_PADDLE_SPEED = 5
+
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (MIN_PADDLE_SPEED <= paddle_speed <= MAX_PADDLE_SPEED):
+            raise ValueError(f"Paddle speed must be between {MIN_PADDLE_SPEED} and {MAX_PADDLE_SPEED}.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
-except (IndexError, ValueError):
-    paddle_speed = 5  # Fallback default
+except (IndexError, ValueError) as e:
+    print(f"Input error: {e} Using default paddle speed {DEFAULT_PADDLE_SPEED}.")
+    paddle_speed = DEFAULT_PADDLE_SPEED
 
 # --- Pygame Setup ---
 pygame.init()
 width, height = 800, 600
 screen = pygame.display.set_mode((width, height))
-pygame.display.set_caption("Vulnerable Ping Pong")
+pygame.display.set_caption("Secure Ping Pong")
 
 # Game Elements
 ball = pygame.Rect(width // 2, height // 2, 15, 15)


### PR DESCRIPTION
This pull request addresses the security vulnerability described in issue #599 by restricting paddle_speed to a safe range (1-20) and improving input validation in main.py.\n\n- Input is now validated to ensure it is a positive integer within the allowed range.\n- Clear error messages are provided for invalid input.\n- Default paddle speed is used if input is missing or invalid.\n\nPlease review and merge to enhance the security and stability of the game.