### PR TITLE
Fix: Enforce bounds on paddle speed input to mitigate DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,15 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line with bounds checking ---
+MIN_PADDLE_SPEED = 1
+MAX_PADDLE_SPEED = 20
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed < MIN_PADDLE_SPEED or paddle_speed > MAX_PADDLE_SPEED:
+            raise ValueError(f"Paddle speed must be between {MIN_PADDLE_SPEED} and {MAX_PADDLE_SPEED}.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):
@@ -16,7 +20,7 @@ except (IndexError, ValueError):
 pygame.init()
 width, height = 800, 600
 screen = pygame.display.set_mode((width, height))
-pygame.display.set_caption("Vulnerable Ping Pong")
+pygame.display.set_caption("Secure Ping Pong")
 
 # Game Elements
 ball = pygame.Rect(width // 2, height // 2, 15, 15)


### PR DESCRIPTION
This pull request addresses a security vulnerability in main.py where paddle speed input from the command line was not properly bounded. The fix enforces a minimum and maximum value (1-20) for paddle speed, preventing denial-of-service or instability due to excessive values.\n\n- Input is validated for both type and range.\n- Fallback default remains 5 if input is invalid.\n\nReferences:\n- https://owasp.org/www-community/Input_Validation\n- https://owasp.org/www-community/attacks/Denial_of_Service