### PR TITLE
Fix: Enforce upper bound on paddle_speed for security (DoS mitigation)

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,15 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
+MIN_PADDLE_SPEED = 1
+MAX_PADDLE_SPEED = 20
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (MIN_PADDLE_SPEED <= paddle_speed <= MAX_PADDLE_SPEED):
+            raise ValueError(f"Paddle speed must be between {MIN_PADDLE_SPEED} and {MAX_PADDLE_SPEED}.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):
@@ -16,7 +20,7 @@ except (IndexError, ValueError):
 pygame.init()
 width, height = 800, 600
 screen = pygame.display.set_mode((width, height))
-pygame.display.set_caption("Vulnerable Ping Pong")
+pygame.display.set_caption("Secure Ping Pong")
 
 # Game Elements
 ball = pygame.Rect(width // 2, height // 2, 15, 15)


### PR DESCRIPTION
This pull request addresses a security vulnerability in main.py where paddle_speed was not bounded, allowing potential denial of service (DoS) by setting excessively high values.\n\n**Changes:**\n- Enforces paddle_speed to be between 1 and 20.\n- Provides clear error messages and safe fallback.\n- Follows best practices for input validation in Python.\n\nReferences:\n- [Python Input Validation](https://docs.python.org/3/tutorial/inputoutput.html)\n- [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices/)\n- [Real Python: Input Validation](https://realpython.com/python-input-validation/)\n\nCloses: Security Vulnerability Issue (unbounded paddle_speed)