### PR TITLE
Fix: Enforce strict type and range checks for paddle_speed (1-20)

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,13 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the security vulnerability in main.py by enforcing strict type and range checks for paddle_speed, ensuring it is between 1 and 20. This mitigates the risk of denial of service or gameplay issues due to excessively large input values. See the related issue for details and supporting information.