### PR TITLE
Restrict paddle_speed to a safe range (1-20) for enhanced security

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,12 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Restrict paddle_speed to a safe range (1-20)
+        if paddle_speed < 1:
+            paddle_speed = 1
+        elif paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the security concern identified in issue #631 by restricting the paddle_speed input in main.py to a safe range (1-20). This change enhances the robustness and security of the application by preventing abuse or accidental misuse of the paddle speed parameter.