### PR TITLE
Fix: Secure Input Validation for Paddle Speed in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,22 +1,17 @@
-import re
+import argparse
 import pygame
-import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
-try:
-    user_input = sys.argv[1]
-    if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
-    else:
-        raise ValueError("Invalid input: Only positive integers are allowed.")
-except (IndexError, ValueError):
-    paddle_speed = 5  # Fallback default
+# --- Secure Input: Paddle speed from command-line ---
+parser = argparse.ArgumentParser()
+parser.add_argument('--paddle_speed', type=int, default=5, choices=range(1, 21), help='Paddle speed (1-20)')
+args = parser.parse_args()
+paddle_speed = args.paddle_speed
 
 # --- Pygame Setup ---
-pygame.init()
 width, height = 800, 600
+pygame.init()
 screen = pygame.display.set_mode((width, height))
-pygame.display.set_caption("Vulnerable Ping Pong")
+pygame.display.set_caption("Secure Ping Pong")
 
 # Game Elements
 ball = pygame.Rect(width // 2, height // 2, 15, 15)


### PR DESCRIPTION
This pull request implements secure input handling for paddle speed using argparse, restricting values to 1-20 as recommended in the documented security issue. This addresses the vulnerability described in issue #665.