### PR TITLE
Fix: Enforce upper limit on paddle_speed to prevent DoS attacks

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,13 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line with upper limit ---
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the security vulnerability described in the following issue: https://github.com/aifuturesdemos/mycustomapp/issues/710

**Summary of Fix:**
- Enforced an upper limit (1-20) on paddle_speed input from the command line in main.py to prevent denial-of-service attacks due to excessively large values.

Please review and merge to secure the application.