### PR TITLE
Fix: Enforce upper limit on paddle_speed to prevent resource exhaustion

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,14 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
+MAX_PADDLE_SPEED = 20
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > MAX_PADDLE_SPEED:
+            raise ValueError(f"Paddle speed too high. Maximum allowed is {MAX_PADDLE_SPEED}.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the security vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/747 by enforcing an upper limit on paddle_speed in main.py. Input is now restricted to a maximum value of 20 to prevent resource exhaustion and denial of service.