### PR TITLE
Fix: Enforce upper bound on paddle_speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,14 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line with upper bound ---
+MAX_PADDLE_SPEED = 20
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > MAX_PADDLE_SPEED:
+            paddle_speed = MAX_PADDLE_SPEED  # Enforce upper bound
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the critical security vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/771 by enforcing an upper bound (MAX_PADDLE_SPEED = 20) on the paddle_speed parameter. This prevents denial of service attacks caused by excessively high paddle speeds and ensures stable gameplay.