### PR TITLE
Fix: Restrict paddle_speed input to 1-20 to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Enforce upper bound for security
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("paddle_speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the critical security vulnerability described in [GitHub Issue #801](https://github.com/aifuturesdemos/mycustomapp/issues/801). The fix enforces an upper bound (1-20) for paddle_speed input in main.py to prevent denial of service or application crash due to excessively large values.