### PR TITLE
Fix: Restrict paddle speed input to safe range (1-20) to address security vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Restrict paddle speed to a reasonable range (1-20)
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the security vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/803 by restricting the paddle speed input in main.py to a safe range (1-20). This prevents denial of service and application instability due to excessively large input values.