### PR TITLE
Fix: Add upper bound to paddle_speed input to prevent DoS and logic abuse

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,11 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Apply upper bound to prevent abuse
+        if paddle_speed < 1:
+            paddle_speed = 1
+        elif paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the critical security vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/825 by adding an upper bound (1-20) to the paddle_speed input in main.py. This prevents denial of service and logic abuse by restricting paddle speed to a safe range.