### PR TITLE
Fix: Add bounds checking for paddle_speed input (must be 1-20)

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,13 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses a security vulnerability in main.py where paddle_speed from the command line was not properly bounded. Now, paddle_speed must be between 1 and 20, preventing denial of service or instability.