### PR TITLE
Clamp paddle_speed to a maximum of 20 to prevent denial of service and gameplay instability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            paddle_speed = 20  # Clamp to upper bound
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses a critical security vulnerability in main.py where paddle_speed could be set to an unreasonably high value from user input. The code now clamps paddle_speed to a maximum of 20, preventing denial of service and gameplay instability. See the updated issue template for details and supporting information.