### PR TITLE
Mitigate DoS vulnerability: Enforce upper bound on paddle_speed

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            paddle_speed = 20  # Clamp to upper bound
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses a critical security vulnerability in main.py where paddle_speed could be set to an excessively high value via command-line input, resulting in a denial of service (DoS). The fix enforces an upper bound of 20 on paddle_speed, mitigating the risk. Please review and merge to secure the application.