### PR TITLE
Fix: Enforce upper bound on paddle_speed to resolve DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,14 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
+MAX_PADDLE_SPEED = 20
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > MAX_PADDLE_SPEED:
+            paddle_speed = MAX_PADDLE_SPEED  # Clamp to upper bound
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request resolves the documented security vulnerability in main.py by enforcing an upper bound (20) on paddle_speed, preventing denial of service via excessively large input values. See the updated issue template for details.