### PR TITLE
Fix: Restrict paddle speed input to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,14 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Restrict paddle speed to a safe maximum value
+        if paddle_speed > 20:
+            raise ValueError("Paddle speed too high. Maximum allowed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the security vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/854 by restricting the paddle speed input in main.py to a maximum value of 20. This prevents denial of service attacks caused by excessively large input values.