### PR TITLE
Restrict paddle speed input to range 1-20 to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the security vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/899. The fix restricts paddle speed input to a safe range (1-20), preventing denial of service by excessively large values.