### PR TITLE
Enforce upper limit on paddle_speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            paddle_speed = 20  # Enforce upper limit
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the issue of unrestricted paddle speed input in main.py, as described in https://github.com/aifuturesdemos/mycustomapp/issues/909. The fix enforces an upper limit of 20 on paddle_speed, preventing denial of service and ensuring stable gameplay.