### PR TITLE
Fix: Enforce upper bound on paddle_speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,12 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Enforce upper and lower bounds to prevent DoS
+        if paddle_speed < 1:
+            paddle_speed = 1
+        elif paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the DoS vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/919 by enforcing an upper bound on the paddle_speed input (now clamped between 1 and 20). This prevents resource exhaustion and ensures stable gameplay.