### PR TITLE
Fix: Enforce strict bounds on paddle_speed and robust input validation

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,15 +2,26 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
-try:
-    user_input = sys.argv[1]
-    if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
-    else:
-        raise ValueError("Invalid input: Only positive integers are allowed.")
-except (IndexError, ValueError):
-    paddle_speed = 5  # Fallback default
+# --- Secure Input: Paddle speed from command-line ---
+MIN_PADDLE_SPEED = 1
+MAX_PADDLE_SPEED = 20
+DEFAULT_PADDLE_SPEED = 5
+
+def get_paddle_speed():
+    try:
+        user_input = sys.argv[1]
+        if re.match(r'^\d+$', user_input):
+            paddle_speed = int(user_input)
+            if MIN_PADDLE_SPEED <= paddle_speed <= MAX_PADDLE_SPEED:
+                return paddle_speed
+            else:
+                raise ValueError("Paddle speed must be between {} and {}.".format(MIN_PADDLE_SPEED, MAX_PADDLE_SPEED))
+        else:
+            raise ValueError("Invalid input: Only positive integers are allowed.")
+    except (IndexError, ValueError):
+        return DEFAULT_PADDLE_SPEED
+
+paddle_speed = get_paddle_speed()
 
 # --- Pygame Setup ---
 pygame.init()


### PR DESCRIPTION
This pull request addresses the critical input validation vulnerability described in [GitHub Issue #935](https://github.com/aifuturesdemos/mycustomapp/issues/935). The fix enforces paddle_speed to be between 1 and 20, rejects invalid or out-of-range input, and defaults to a safe value. This prevents denial of service and integer overflow risks.