### PR TITLE
Fix: Add upper bound check for paddle_speed to prevent denial-of-service

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            raise ValueError("Input too large: Maximum allowed paddle speed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [GitHub Issue #951](https://github.com/aifuturesdemos/mycustomapp/issues/951) by adding an upper bound check for paddle_speed in main.py. The fix ensures that paddle_speed cannot exceed 20, preventing denial-of-service via resource exhaustion.