### PR TITLE
Fix: Add upper bound to paddle_speed input validation

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Enforce a reasonable upper bound for paddle_speed
+        if paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/953 by adding a maximum allowed value for paddle_speed (20). Any input above this threshold is clamped to 20, preventing denial-of-service via excessively large values and ensuring the game remains playable and secure.