### PR TITLE
Fix: Restrict paddle_speed input to prevent resource exhaustion

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [GitHub Issue #957](https://github.com/aifuturesdemos/mycustomapp/issues/957) by limiting the paddle_speed input in main.py to the range 1-20. This prevents resource exhaustion and denial of service by ensuring paddle_speed cannot be set to an excessively high value.