### PR TITLE
Fix: Limit paddle_speed to prevent denial-of-service

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Security fix: Limit paddle_speed to a maximum of 20
+        if paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/969.\n\nThe fix enforces a maximum value of 20 for paddle_speed, preventing denial-of-service or resource exhaustion attacks caused by excessively large command-line input. The code now validates and clamps paddle_speed to a safe range.