### PR TITLE
Enforce maximum paddle speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Enforce upper bound to prevent DoS
+        if paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [GitHub Issue #977](https://github.com/aifuturesdemos/mycustomapp/issues/977) by enforcing an upper bound on paddle speed input in main.py. The fix ensures paddle speed cannot exceed 20, preventing denial of service attacks caused by excessively high values.