### PR TITLE
Fix: Enforce upper bound on paddle_speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,12 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Enforce upper bound to prevent DoS
+        if paddle_speed < 1:
+            paddle_speed = 1
+        elif paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [GitHub Issue #981](https://github.com/aifuturesdemos/mycustomapp/issues/981), which describes a denial-of-service vulnerability in main.py due to unbounded paddle_speed input. The fix enforces paddle_speed to be within 1 and 20, preventing resource exhaustion and improving input validation security.