### PR TITLE
Fix: Add upper bound check to paddle speed input to prevent resource exhaustion

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            raise ValueError("Input too large: Maximum allowed paddle speed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [GitHub Issue #983](https://github.com/aifuturesdemos/mycustomapp/issues/983) by adding an upper bound check to the paddle speed input in main.py. The fix restricts paddle speed to a maximum of 20, preventing resource exhaustion and denial of service attacks due to excessively large input values.