### PR TITLE
Fix resource exhaustion vulnerability: enforce paddle speed bounds

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [GitHub Issue #987](https://github.com/aifuturesdemos/mycustomapp/issues/987) by enforcing an upper and lower bound on the paddle speed input (1 to 20). This prevents denial of service via unbounded paddle speed values and ensures the game remains playable.