### PR TITLE
Fix: Add upper bound to paddle speed input validation

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [the documented vulnerability](https://github.com/aifuturesdemos/mycustomapp/issues/993) where paddle speed input lacked an upper bound. The fix enforces a maximum value of 20 for paddle speed, preventing denial of service or gameplay disruption due to excessively large values.