### PR TITLE
Fix: Cap paddle_speed input to prevent resource exhaustion

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            paddle_speed = 20  # Cap paddle speed to max 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [the reported vulnerability](https://github.com/aifuturesdemos/mycustomapp/issues/999) where paddle_speed input was not bounded, allowing denial of service via excessive values. The fix enforces a maximum paddle_speed of 20, ensuring the game remains playable and preventing resource exhaustion.