### PR TITLE
Fix: Limit Paddle Speed to Prevent Denial-of-Service Vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            paddle_speed = 20  # Limit maximum paddle speed
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [GitHub Issue #1001](https://github.com/aifuturesdemos/mycustomapp/issues/1001), which identified a denial-of-service vulnerability due to unbounded paddle speed input. The fix enforces a maximum paddle speed of 20, preventing resource exhaustion and ensuring stable gameplay.