### PR TITLE
Fix: Add upper bound check for paddle_speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            raise ValueError("Input too large: Maximum allowed paddle speed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [the reported vulnerability](https://github.com/aifuturesdemos/mycustomapp/issues/1003) where paddle_speed input was not bounded, allowing a denial-of-service condition. The fix enforces a maximum paddle_speed of 20 to ensure stable gameplay and prevent abuse.