### PR TITLE
Fix: Enforce maximum paddle_speed to prevent denial of service

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            paddle_speed = 20  # Enforce maximum value
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [the reported vulnerability](https://github.com/aifuturesdemos/mycustomapp/issues/1011) where paddle_speed input was unbounded, allowing denial of service or game logic break. The fix enforces a maximum paddle_speed of 20, ensuring game integrity and preventing abuse.