### PR TITLE
Fix: Restrict paddle_speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,14 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
+MAX_PADDLE_SPEED = 20
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > MAX_PADDLE_SPEED:
+            paddle_speed = MAX_PADDLE_SPEED  # Clamp to max allowed
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the critical security vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1015.\n\n- Restricts paddle_speed input to a maximum value (20) to prevent denial-of-service (DoS) attacks via excessively large values.\n- Adds MAX_PADDLE_SPEED constant and clamps input accordingly.\n- See the linked issue for details and impact.