### PR TITLE
Fix: Enforce paddle_speed between 1 and 20 to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Enforce paddle_speed to be between 1 and 20
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1017. The fix enforces paddle_speed to be between 1 and 20, preventing denial-of-service via excessively large values and ensuring stable gameplay.