### PR TITLE
Fix: Restrict paddle_speed to range 1-20 (input validation)

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Enforce upper bound for paddle_speed
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("paddle_speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1023.\n\n**Summary of Fix:**\n- Enforces paddle_speed to be between 1 and 20 after parsing command-line input.\n- Prevents denial-of-service via excessively large paddle_speed values.\n- Ensures stable gameplay and mitigates input abuse.