### PR TITLE
Fix: Cap paddle_speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        MAX_PADDLE_SPEED = 20
+        paddle_speed = min(paddle_speed, MAX_PADDLE_SPEED)  # Cap to prevent DoS
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [GitHub Issue #1027](https://github.com/aifuturesdemos/mycustomapp/issues/1027) by capping the paddle_speed input to a maximum value (20) after validation. This prevents denial-of-service attacks caused by excessively large paddle speeds, ensuring the game remains playable and stable.