### PR TITLE
Fix: Limit paddle_speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            paddle_speed = 20  # Enforce upper bound
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the DoS vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1029.\n\n**Summary of Fix:**\n- Enforces an upper bound of 20 for paddle_speed when read from the command line.\n- Prevents attackers from setting excessively high paddle speeds that could crash or freeze the game.\n\nPlease review and merge to secure the application.