### PR TITLE
Fix: Cap paddle_speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        if paddle_speed > 20:
+            paddle_speed = 20  # Cap paddle speed to prevent abuse
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the security vulnerability described in [Issue #1037](https://github.com/aifuturesdemos/mycustomapp/issues/1037).\n\n- Adds an upper bound check for paddle_speed (max 20) to prevent denial of service via excessively large values.\n- Ensures the game remains playable and resource exhaustion is mitigated.\n\nPlease review and merge to main.