### PR TITLE
Fix: Enforce upper bound on paddle speed input (1-20)

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,13 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the critical security vulnerability documented in [Issue #1043](https://github.com/aifuturesdemos/mycustomapp/issues/1043): No upper bound on paddle speed input. The fix enforces a paddle speed range of 1-20, preventing excessively large values and ensuring game stability.