### PR TITLE
Fix: Enforce bounds on paddle speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,15 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
+MAX_PADDLE_SPEED = 20
+MIN_PADDLE_SPEED = 1
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed < MIN_PADDLE_SPEED or paddle_speed > MAX_PADDLE_SPEED:
+            raise ValueError(f"Paddle speed must be between {MIN_PADDLE_SPEED} and {MAX_PADDLE_SPEED}.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the critical security vulnerability described in [Issue #1049](https://github.com/aifuturesdemos/mycustomapp/issues/1049): Unbounded paddle speed input in main.py could allow a denial-of-service (DoS) attack.\n\n**Fix Applied:**\n- Enforced upper and lower bounds on paddle speed (must be between 1 and 20).\n- Input outside this range is rejected and defaults to a safe value.\n\nPlease review and merge to secure the application.