### PR TITLE
Fix: Enforce upper bound on paddle speed input to prevent DoS

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,13 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the security vulnerability documented in [Issue #1053](https://github.com/aifuturesdemos/mycustomapp/issues/1053): Insufficient input validation on paddle speed allows denial-of-service. The fix enforces an upper bound (1-20) on paddle speed input, preventing extremely large values that could destabilize or crash the game.