### PR TITLE
Fix: Enforce bounds on paddle speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,15 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
+MIN_PADDLE_SPEED = 1
+MAX_PADDLE_SPEED = 20
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (MIN_PADDLE_SPEED <= paddle_speed <= MAX_PADDLE_SPEED):
+            raise ValueError(f"Paddle speed must be between {MIN_PADDLE_SPEED} and {MAX_PADDLE_SPEED}.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the critical security vulnerability documented in [Issue #1057](https://github.com/aifuturesdemos/mycustomapp/issues/1057): unbounded paddle speed input allows a denial-of-service attack. The fix enforces an allowed range (1-20) for paddle speed input, preventing excessively large values from causing the game to become unresponsive or crash.