### PR TITLE
Fix: Add upper-bound validation to paddle speed input to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            raise ValueError("Paddle speed too high. Maximum allowed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [the reported vulnerability](https://github.com/aifuturesdemos/mycustomapp/issues/1059) where paddle speed input from the command line was not upper-bounded, allowing a denial-of-service attack via resource exhaustion. The fix enforces a maximum paddle speed of 20, preventing excessive values and ensuring game stability.