### PR TITLE
Fix: Restrict paddle speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,14 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
+MAX_PADDLE_SPEED = 20
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > MAX_PADDLE_SPEED:
+            paddle_speed = MAX_PADDLE_SPEED  # Enforce upper bound
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the security vulnerability described in [Issue #1063](https://github.com/aifuturesdemos/mycustomapp/issues/1063):

- **Vulnerability:** Paddle speed input from the command line could be set to an excessively large value, leading to a denial-of-service (DoS) condition.
- **Fix:** The code now enforces an upper bound (maximum 20) for paddle speed, preventing abuse.

Please review and merge to main.