### PR TITLE
Fix: Enforce upper bound on paddle_speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # --- FIX: Enforce upper bound on paddle_speed ---
+        if paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the critical security vulnerability described in [Issue #1067](https://github.com/aifuturesdemos/mycustomapp/issues/1067):

- Paddle speed input from the command line is now capped at a maximum value of 20 to prevent denial of service attacks.
- See the linked issue for details and reproduction steps.

Please review and merge to secure the application.