### PR TITLE
Fix: Add upper bound check for paddle_speed to prevent denial-of-service

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            raise ValueError("Input too large: Maximum allowed paddle speed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [the documented vulnerability](https://github.com/aifuturesdemos/mycustomapp/issues/1070) in main.py by adding an upper bound check for paddle_speed (maximum 20). This prevents denial-of-service attacks caused by excessively large paddle speeds and ensures stable game behavior.