### PR TITLE
Fix: Add upper bound check for paddle_speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,14 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line ---
+MAX_PADDLE_SPEED = 20
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > MAX_PADDLE_SPEED:
+            raise ValueError(f"Paddle speed too high (max {MAX_PADDLE_SPEED})")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the critical security vulnerability described in [Issue #1072](https://github.com/aifuturesdemos/mycustomapp/issues/1072):

- Adds an upper bound check for paddle_speed (max 20) to prevent denial of service attacks due to excessively large values.
- Ensures paddle_speed is always within a safe and reasonable range.

Please review and merge to secure the application.