### PR TITLE
Fix: Cap paddle speed to prevent resource exhaustion vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,14 @@ import re
 import pygame
 import sys
 
-# --- Vulnerable Input: Paddle speed from command-line ---
+# --- Secure Input: Paddle speed from command-line with upper bound ---
+MAX_PADDLE_SPEED = 20
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > MAX_PADDLE_SPEED:
+            paddle_speed = MAX_PADDLE_SPEED
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the resource exhaustion vulnerability described in [Issue #1074](https://github.com/aifuturesdemos/mycustomapp/issues/1074). The paddle speed input is now capped at MAX_PADDLE_SPEED (20) to prevent denial of service and ensure stable gameplay.