### PR TITLE
Fix: Limit Paddle Speed to Prevent Denial-of-Service

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            raise ValueError("Paddle speed too high. Maximum allowed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [GitHub Issue #1085](https://github.com/aifuturesdemos/mycustomapp/issues/1085) by enforcing a maximum paddle speed of 20 in main.py. This prevents denial-of-service attacks caused by excessively large paddle speed values from user input. The code now rejects values above 20 and provides a clear error message.