### PR TITLE
Restrict paddle_speed input to range 1-20 to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Input out of allowed range (1-20).")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [GitHub Issue #1087](https://github.com/aifuturesdemos/mycustomapp/issues/1087). The fix enforces a range check on paddle_speed (1-20) for command-line input, preventing denial of service via excessively large values and ensuring stable gameplay.