### PR TITLE
Enforce maximum allowed paddle speed to prevent denial of service

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Enforce maximum allowed paddle speed
+        if paddle_speed > 20:
+            raise ValueError("Paddle speed too high. Maximum allowed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses [GitHub Issue #1091](https://github.com/aifuturesdemos/mycustomapp/issues/1091) by enforcing a maximum allowed paddle speed in main.py. The fix prevents denial of service and game instability by rejecting excessively large paddle speed values.