### PR TITLE
Restrict paddle_speed input to range 1-20 to prevent resource exhaustion vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Restrict paddle_speed to a safe range
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the resource exhaustion vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1110. The fix restricts paddle_speed input to a safe range (1-20) to prevent denial-of-service and ensure stable gameplay.