### PR TITLE
Limit paddle_speed input to range 1-20 to prevent denial of service

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,12 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Limit paddle_speed to a reasonable maximum value
+        if paddle_speed < 1:
+            paddle_speed = 1
+        elif paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability documented in https://github.com/aifuturesdemos/mycustomapp/issues/1120 by limiting the paddle_speed input to a range of 1-20, preventing denial of service and ensuring stable gameplay.