### PR TITLE
Limit paddle speed input to prevent resource exhaustion

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Limit paddle speed to a maximum value
+        if paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1128 by limiting paddle speed input to a maximum value of 20. The fix prevents resource exhaustion and gameplay disruption by ensuring paddle speed remains within a safe range.