### PR TITLE
Bound paddle_speed input to maximum 20 to prevent denial of service

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Apply bounding to prevent abuse
+        if paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability documented in https://github.com/aifuturesdemos/mycustomapp/issues/1132 by bounding the paddle_speed input to a maximum of 20. This prevents denial of service attacks caused by excessively large paddle speeds and ensures game stability.