### PR TITLE
Fix: Restrict paddle_speed input to safe range (1–20)

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,10 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        if 1 <= paddle_speed <= 20:
+            pass  # Valid range
+        else:
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1140. The fix adds a range check to the paddle_speed input, ensuring only values between 1 and 20 are accepted. This prevents denial-of-service and game instability caused by excessively large paddle speeds.