### PR TITLE
Enforce bounds for paddle_speed to prevent extreme values

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,11 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Enforce upper and lower bounds for paddle_speed
+        if paddle_speed < 1:
+            paddle_speed = 1
+        elif paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1146 by enforcing upper and lower bounds for paddle_speed in main.py. The fix ensures paddle_speed is limited between 1 and 20, preventing gameplay manipulation and denial of service due to extreme values.