### PR TITLE
Add input bounds check for paddle_speed

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Enforce bounds: 1 <= paddle_speed <= 20
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Input out of bounds: paddle_speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the critical vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1148. The fix enforces an upper bound for paddle_speed (1 <= paddle_speed <= 20) to prevent excessive values and denial of service.