### PR TITLE
Restrict paddle speed input to range 1-20 and add stricter validation to prevent denial-of-service

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Input out of range: Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1152. The fix restricts paddle speed input to a range of 1-20 and adds stricter validation to prevent denial-of-service attacks caused by unbounded integer input.