### PR TITLE
Add upper limit validation for paddle_speed to prevent denial of service

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Added upper limit enforcement
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Input out of allowed range (1-20).")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1158 by adding an upper limit validation for paddle_speed (1-20) in main.py. Input outside this range is rejected to prevent denial of service and gameplay instability.