### PR TITLE
Fix: Cap paddle_speed to prevent denial of service

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            paddle_speed = 20  # Cap to maximum allowed value
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the input validation vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1162. The paddle_speed input is now capped at a maximum value of 20, preventing denial of service via excessively large input.