### PR TITLE
Add upper bound check for paddle speed to prevent denial of service

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Added upper bound check for paddle speed
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability documented in https://github.com/aifuturesdemos/mycustomapp/issues/1168 by adding an upper bound check for paddle speed (1-20) in main.py. The fix prevents denial of service attacks caused by excessively large paddle speed values.