### PR TITLE
Restrict paddle_speed input to range 1-20 to prevent denial-of-service vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Restrict paddle_speed to a reasonable range
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1175 by restricting paddle_speed input to the range 1-20 in main.py, preventing denial-of-service attacks caused by unbounded numeric input.