### PR TITLE
Add upper bound check for paddle_speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Add upper bound check
+        if paddle_speed > 20:
+            raise ValueError("Paddle speed too high: Maximum allowed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1179 by adding an upper bound check for paddle_speed in main.py. The fix restricts paddle_speed to a maximum of 20, preventing denial-of-service and game instability due to excessive values.