### PR TITLE
Add maximum allowed value check for paddle_speed to prevent denial-of-service vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Enforce maximum allowed value
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Invalid input: Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the critical vulnerability documented in https://github.com/aifuturesdemos/mycustomapp/issues/1184. The fix enforces a maximum allowed value for paddle_speed (1–20), preventing denial-of-service attacks caused by excessively large input values.