### PR TITLE
Add upper bound check to paddle speed input to prevent denial of service or game disruption

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Add upper bound check to prevent abuse
+        if paddle_speed > 20:
+            raise ValueError("Paddle speed too high. Maximum allowed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability documented in https://github.com/aifuturesdemos/mycustomapp/issues/1186. The fix adds an upper bound check to the paddle speed input, ensuring values above 20 are rejected to prevent denial of service or gameplay disruption.