### PR TITLE
Add upper bound check for paddle_speed to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Add upper bound check
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the denial-of-service risk in main.py by adding an upper bound check for paddle_speed. See the related issue: https://github.com/aifuturesdemos/mycustomapp/issues/1190. The fix ensures paddle_speed is restricted to the range 1–20, preventing resource exhaustion and game crashes.