### PR TITLE
Enforce upper bound for paddle_speed to prevent DoS/game instability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Enforce upper bound for paddle_speed
+        if paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability documented in [GitHub Issue](https://github.com/aifuturesdemos/mycustomapp/issues/1195). The fix enforces an upper bound for paddle_speed (maximum 20) to prevent denial-of-service and maintain game stability.