### PR TITLE
Add maximum allowed value check for paddle_speed

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Enforce maximum allowed value for paddle_speed
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Invalid input: paddle_speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1199 by enforcing a maximum allowed value for paddle_speed (1-20) in main.py, preventing resource exhaustion and denial-of-service attacks.