### PR TITLE
Enforce maximum paddle speed limit to fix security vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Enforce maximum paddle speed
+        if paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the issue described at https://github.com/aifuturesdemos/mycustomapp/issues/1207. The fix enforces a maximum paddle speed of 20, preventing denial-of-service and instability caused by unbounded user input.