### PR TITLE
Fix: Add upper bound to paddle speed input to prevent resource exhaustion

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if paddle_speed > 20:
+            raise ValueError("Paddle speed too high: maximum allowed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the resource exhaustion vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1209. The fix enforces an upper limit (max 20) on the paddle speed input, preventing denial of service by restricting excessively high values.