### PR TITLE
Enforce maximum allowed paddle_speed value to mitigate denial of service vulnerability.

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Enforce maximum allowed value
+        if paddle_speed > 20:
+            raise ValueError("Input too large: Maximum allowed paddle speed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
See issue: https://github.com/aifuturesdemos/mycustomapp/issues/1211. The fix enforces a maximum allowed paddle_speed value of 20 in main.py. Any input above this threshold is rejected, mitigating the denial of service vulnerability.