### PR TITLE
Enforce upper bound for paddle_speed to mitigate DoS risk

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Enforce upper bound for paddle_speed
+        if paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1213 by enforcing an upper bound for paddle_speed in main.py. The fix ensures that paddle_speed cannot exceed 20, preventing denial-of-service (DoS) attacks caused by excessive values.