### PR TITLE
Limit paddle_speed to prevent denial of service and instability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        if paddle_speed > 20:
+            paddle_speed = 20  # Limit to maximum allowed value
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the critical vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1215. The fix limits paddle_speed to a maximum of 20, preventing denial of service and ensuring stable gameplay.