### PR TITLE
Fix: Restrict paddle_speed to prevent denial of service vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Restrict paddle_speed to a maximum value of 20
+        if paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the critical vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1223. The fix restricts paddle_speed to a maximum value of 20, preventing abuse and ensuring stable gameplay.