### PR TITLE
Add upper bound check for paddle_speed to prevent denial-of-service and gameplay manipulation

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,10 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Add upper bound check
+        MAX_PADDLE_SPEED = 20
+        if paddle_speed > MAX_PADDLE_SPEED:
+            paddle_speed = MAX_PADDLE_SPEED
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1227 by adding an upper bound check for paddle_speed in main.py. The fix restricts paddle_speed to a maximum value (20), preventing denial-of-service and gameplay manipulation due to excessive input values.