### PR TITLE
Limit paddle_speed to prevent denial-of-service vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Limit paddle_speed to a reasonable maximum
+        if paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability documented in [GitHub Issue #1237](https://github.com/aifuturesdemos/mycustomapp/issues/1237). The fix limits paddle_speed to a maximum of 20 after input validation, preventing denial-of-service and gameplay disruption.