### PR TITLE
Enforce upper bound on paddle_speed to prevent denial-of-service

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Enforce upper bound to prevent DoS
+        if paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1243 by enforcing an upper bound (maximum 20) on paddle_speed. This prevents denial-of-service attacks by limiting excessively high values and ensures the game remains playable.