### PR TITLE
Restrict paddle_speed input to range 1-20 to prevent integer overflow/resource exhaustion vulnerability.

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Input out of range: Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
Fix for [https://github.com/aifuturesdemos/mycustomapp/issues/1250](https://github.com/aifuturesdemos/mycustomapp/issues/1250): Paddle speed input is now restricted to values between 1 and 20, preventing integer overflow and resource exhaustion attacks.