### PR TITLE
Add maximum allowed value check for paddle_speed to prevent denial of service

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Enforce maximum allowed value
+        if paddle_speed > 20:
+            raise ValueError("Input too large: Maximum allowed paddle speed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the critical vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1252 by adding a maximum allowed value check for paddle_speed (max 20). This prevents denial of service attacks caused by unbounded user input.