### PR TITLE
Restrict paddle_speed to maximum value to fix vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Restrict paddle_speed to a maximum value
+        if paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the unrestricted paddle_speed vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1257. The fix restricts paddle_speed to a maximum value of 20, preventing denial of service and ensuring stable gameplay.