### PR TITLE
Fix: Enforce upper bound for paddle_speed to prevent denial-of-service vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,11 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Enforce upper bound for paddle_speed
+        if paddle_speed < 1:
+            paddle_speed = 1
+        elif paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in [GitHub Issue](https://github.com/aifuturesdemos/mycustomapp/issues/1261). The fix enforces an upper bound (1–20) for paddle_speed, preventing denial-of-service and resource exhaustion by restricting excessively large input values.