### PR TITLE
Enforce maximum paddle speed of 20 to prevent denial-of-service vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        if paddle_speed > 20:
+            raise ValueError("Paddle speed too high: Maximum allowed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
Fixes [https://github.com/aifuturesdemos/mycustomapp/issues/1269](https://github.com/aifuturesdemos/mycustomapp/issues/1269). Input validation logic updated to enforce a maximum paddle speed of 20, rejecting values above this threshold to prevent denial-of-service attacks.