### PR TITLE
Add upper limit to paddle_speed input validation to prevent denial-of-service vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (1 <= paddle_speed <= 100):
+            raise ValueError("Invalid input: Paddle speed must be between 1 and 100.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability documented in [GitHub Issue #1273](https://github.com/aifuturesdemos/mycustomapp/issues/1273). The fix adds an explicit upper limit (1 <= paddle_speed <= 100) to the input validation logic in main.py, rejecting values outside this range and preventing denial-of-service attacks caused by resource exhaustion.