### PR TITLE
Fix: Enforce upper bound for paddle_speed to prevent denial-of-service

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Enforce upper bound for paddle_speed
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1287 by enforcing an upper bound (1–20) for paddle_speed input in main.py. The fix prevents denial-of-service attacks caused by excessively large values and ensures stable operation.