### PR TITLE
Restrict paddle_speed to 1-20 to prevent DoS vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Restrict paddle_speed to a reasonable maximum
+        if paddle_speed < 1 or paddle_speed > 20:
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1291 by restricting paddle_speed to a maximum of 20 and a minimum of 1. The fix prevents denial-of-service attacks caused by excessively large paddle speeds.