### PR TITLE
Add upper bound check for paddle_speed to prevent denial-of-service

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        if paddle_speed > 20:
+            raise ValueError("Paddle speed too high: Maximum allowed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1295 by adding an upper bound check for paddle_speed (maximum allowed is 20). This prevents denial-of-service attacks caused by excessively high paddle speeds and ensures the game remains playable.