### PR TITLE
Restrict paddle_speed input to range 1-20 to prevent denial of service

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Restrict paddle_speed to a reasonable range
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Input out of range: Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
See issue: https://github.com/aifuturesdemos/mycustomapp/issues/1301. The fix restricts paddle_speed to a range of 1-20, preventing denial of service attacks by limiting excessive input values.