### PR TITLE
Restrict paddle_speed input to prevent denial of service

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Input out of range: Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability documented in https://github.com/aifuturesdemos/mycustomapp/issues/1305 by restricting the paddle_speed input to the range 1-20. The fix prevents denial of service and gameplay instability caused by excessively large values.