### PR TITLE
Clamp paddle_speed input to range 1–20 to prevent denial-of-service risk

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,11 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Clamp paddle_speed to a safe range
+        if paddle_speed < 1:
+            paddle_speed = 1
+        elif paddle_speed > 20:
+            paddle_speed = 20
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in [GitHub Issue #1311](https://github.com/aifuturesdemos/mycustomapp/issues/1311). The paddle_speed input is now clamped to the range 1–20, preventing denial-of-service attacks from excessively large values.