### PR TITLE
Add upper limit to paddle_speed input to prevent denial-of-service

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        if paddle_speed > 20:
+            raise ValueError("Input too high: Maximum allowed paddle speed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1316 by enforcing an upper bound (maximum 20) on the paddle_speed input in main.py. The fix prevents denial-of-service attacks caused by excessively high paddle speeds and ensures stable gameplay.