### PR TITLE
Add upper bound check for paddle speed to prevent denial of service

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Add upper bound check
+        if paddle_speed > 20:
+            raise ValueError("Paddle speed too high. Maximum allowed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
Fixes https://github.com/aifuturesdemos/mycustomapp/issues/1318. Added an upper bound check for paddle speed (maximum allowed is 20). If the input exceeds this value, the program reverts to the default speed, preventing abuse and ensuring stable gameplay.