### PR TITLE
Enforce upper bound for paddle_speed to prevent denial-of-service vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Enforce upper bound for paddle_speed
+        if paddle_speed < 1 or paddle_speed > 20:
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1324 by enforcing an upper bound (1–20) for paddle_speed in main.py. The fix prevents denial-of-service attacks caused by excessively large input values and ensures stable gameplay.