### PR TITLE
Add upper bound check for paddle_speed to prevent resource exhaustion

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        # Add upper bound check for paddle_speed
+        if paddle_speed > 20:
+            raise ValueError("Input too high: Maximum allowed paddle speed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1330 by adding an upper bound check for paddle_speed in main.py. The fix restricts paddle_speed to a maximum of 20, preventing denial-of-service and game instability due to excessively high values.