### PR TITLE
Restrict paddle_speed input to prevent denial-of-service vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ import sys
 try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
-        paddle_speed = int(user_input)  # Validated input
+        paddle_speed = int(user_input)
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
See GitHub Issue: https://github.com/aifuturesdemos/mycustomapp/issues/1336

Fix applied: Restricted paddle_speed input to values between 1 and 20 to prevent denial-of-service vulnerability.