### PR TITLE
Restrict paddle_speed input to range 1-20 to prevent denial-of-service vulnerability.

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        if not (1 <= paddle_speed <= 20):
+            raise ValueError("Invalid input: Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1338. The fix restricts paddle_speed input to a range of 1-20, preventing denial-of-service by rejecting excessively large values.