### PR TITLE
Fix: Enforce upper bound for paddle_speed input to prevent denial-of-service vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,10 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        if 1 <= paddle_speed <= 20:
+            pass  # paddle_speed is valid
+        else:
+            raise ValueError("Input out of range: Paddle speed must be between 1 and 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
This pull request addresses the vulnerability described in [GitHub Issue](https://github.com/aifuturesdemos/mycustomapp/issues/1344). The fix enforces an upper bound (1–20) for paddle_speed input, preventing denial-of-service attacks caused by resource exhaustion. The code now validates the input and resets to a safe default if out of range.