### PR TITLE
Fix: Restrict paddle_speed to prevent denial of service

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Restrict paddle_speed to a reasonable maximum value
+        if paddle_speed > 20:
+            raise ValueError("Input too large: Maximum allowed paddle speed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
Fixes security vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1349. Restricts paddle_speed to a maximum value of 20 to prevent denial of service or instability.