### PR TITLE
Fix: Add upper bound check for paddle_speed to prevent denial-of-service risk

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ try:
     user_input = sys.argv[1]
     if re.match(r'^\d+$', user_input):
         paddle_speed = int(user_input)  # Validated input
+        # Add upper bound check
+        if paddle_speed > 20:
+            raise ValueError("Input too large: Maximum allowed paddle speed is 20.")
     else:
         raise ValueError("Invalid input: Only positive integers are allowed.")
 except (IndexError, ValueError):


### PR DESCRIPTION
Fixes security vulnerability described in https://github.com/aifuturesdemos/mycustomapp/issues/1359. Adds an upper bound check for paddle_speed to prevent denial-of-service risk. Paddle speed is now limited to a maximum of 20.